### PR TITLE
Custom request headers

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -55,19 +55,23 @@ module.exports = class Request extends Collection {
     };
   }
 
-  send(url, method, body = {}) {
+  send(url, method, body, headers) {
     return new Promise((resolve, reject) => {
       // request interceptors
-      let finalHeaders = this.standardHeader;
+      let allHeaders = this.standardHeader;
+      if (headers)
+      Object.keys(headers).forEach(header => {
+        allHeaders[header] = headers[header];
+      });
       let fullURL = `${this._global.dataRef.request.baseURL}/${url}`;
       body = JSON.stringify(body);
       // if (this._pendingRequests.includes(fullURL)) return;
       // this._pendingRequests.push(fullURL);
-      const headers = Object.assign(finalHeaders, {
+      const finalHeaders = Object.assign(allHeaders, {
         method: method.toUpperCase(),
         body: method == 'get' ? null : body
       });
-      fetch(fullURL, headers)
+      fetch(fullURL, finalHeaders)
         .then(response => {
           // if weird status reject()
           // historic status
@@ -114,19 +118,19 @@ module.exports = class Request extends Collection {
     });
   }
 
-  get(url) {
-    return this.send(url, 'get');
+  get(url, headers) {
+    return this.send(url, 'get', {}, headers);
   }
-  post(url, body) {
-    return this.send(url, 'post', body);
+  post(url, body, headers) {
+    return this.send(url, 'post', body, headers);
   }
-  patch(url, body) {
-    return this.send(url, 'patch', body);
+  patch(url, body, headers) {
+    return this.send(url, 'patch', body, headers);
   }
-  delete(url, body) {
-    return this.send(url, 'delete', body);
+  delete(url, body, headers) {
+    return this.send(url, 'delete', body, headers);
   }
-  put(url, body) {
-    return this.send(url, 'put', body);
+  put(url, body, headers) {
+    return this.send(url, 'put', body, headers);
   }
 };


### PR DESCRIPTION
This adds the ability to pass custom headers to the request.

```javascript
send(url, method, body, headers)
get(url, headers)
post(url, body, headers)
patch(url, body, headers)
delete(url, body, headers)
put(url, body, headers)
```
* Headers are optional

**This is not tested**