### PR TITLE
Remove overwriting of custom Content-Type header

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -63,7 +63,7 @@ module.exports = class Request extends Collection {
         });
 
       // If method is not get set application type
-      if (method != 'get') requestHeaders['Content-Type'] = 'application/json';
+      if (method != 'get' && requestHeaders['Content-Type'] === undefined) requestHeaders['Content-Type'] = 'application/json';
 
       let fullURL;
 


### PR DESCRIPTION
## Description
If you set a custom Content-Type header on your request, it gets overwritten.

Now there is a check if the Content-Type header is already set. If not, the default Content-Type header gets set.

## Related Issue

## Context

## How Has This Been Tested?