### PR TITLE
add multipart/form-data support

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -62,15 +62,12 @@ module.exports = class Request extends Collection {
           requestHeaders[header] = headers[header];
         });
 			
-			// Stringify body
-			if (requestHeaders['Content-Type'] !== 'multipart/form-data')
-      	body = JSON.stringify(body);
+      // Stringify body
+      if (requestHeaders['Content-Type'] !== 'multipart/form-data') body = JSON.stringify(body);
 
       // If method is not get set application type
       if (method != 'get' && requestHeaders['Content-Type'] === undefined) requestHeaders['Content-Type'] = 'application/json';
-			if (requestHeaders['Content-Type'] === 'multipart/form-data') {
-				delete requestHeaders['Content-Type'];	
-			}
+      if (requestHeaders['Content-Type'] === 'multipart/form-data')delete requestHeaders['Content-Type'];
       let fullURL;
 
       if (url.startsWith('http')) fullURL = url;

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -67,7 +67,7 @@ module.exports = class Request extends Collection {
 
       // If method is not get set application type
       if (method != 'get' && requestHeaders['Content-Type'] === undefined) requestHeaders['Content-Type'] = 'application/json';
-      if (requestHeaders['Content-Type'] === 'multipart/form-data')delete requestHeaders['Content-Type'];
+      if (requestHeaders['Content-Type'] === 'multipart/form-data') delete requestHeaders['Content-Type'];
       let fullURL;
 
       if (url.startsWith('http')) fullURL = url;

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -61,17 +61,20 @@ module.exports = class Request extends Collection {
         Object.keys(headers).forEach(header => {
           requestHeaders[header] = headers[header];
         });
+			
+			// Stringify body
+			if (requestHeaders['Content-Type'] !== 'multipart/form-data')
+      	body = JSON.stringify(body);
 
       // If method is not get set application type
       if (method != 'get' && requestHeaders['Content-Type'] === undefined) requestHeaders['Content-Type'] = 'application/json';
-
+			if (requestHeaders['Content-Type'] === 'multipart/form-data') {
+				delete requestHeaders['Content-Type'];	
+			}
       let fullURL;
 
       if (url.startsWith('http')) fullURL = url;
       else fullURL = `${this._global.dataRef.request.baseURL}/${url}`;
-
-      // Stringify body
-      body = JSON.stringify(body);
 
       // Build options
       this._options = {};
@@ -114,7 +117,7 @@ module.exports = class Request extends Collection {
           // inject headers into prototype
           let final;
 
-          // If reponse body is an object, create a custom object with response function in prototype, so headers and the full response data can be accessed outside of this class
+          // If response body is an object, create a custom object with response function in prototype, so headers and the full response data can be accessed outside of this class
           if (!Array.isArray(body) && typeof body === 'object') {
             final = Object.create({
               response: () => {


### PR DESCRIPTION
## Description
When you want to send a multipart request you basically use
```javascript
let formData = new FormData();
formData.append(....);
``` 
The body of your request becomes the `formData`.
Usually you pass a Content-Type header, like `application/json`.
When you use the formData thing, your browser adds the `Content-Type: multipart/form-data` header and appends boundaries.

This is the reason for this piece of code, that basically deletes the header out of the request.
```javascript
if (requestHeaders['Content-Type'] === 'multipart/form-data') {
  delete requestHeaders['Content-Type'];	
}
```

Because the body is not in a JSON format, I added this check:
```javascript
if (requestHeaders['Content-Type'] !== 'multipart/form-data')
    body = JSON.stringify(body);
```

Also see https://github.com/github/fetch/issues/505 

## Related Issue

## Context

## How Has This Been Tested?
