### PR TITLE
Fix deletedData being wrong in the delete method

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -1653,7 +1653,7 @@ module.exports = class Collection {
       );
     const deleteFunction = primaryKey => {
       // preserve data
-      let deletedData = Object.assign({}, this._data.primaryKey);
+      let deletedData = Object.assign({}, this._data[primaryKey]);
       // delete data
       delete this._data[primaryKey];
       // record deletion


### PR DESCRIPTION
Jamie used the wrong thing and now I have fixed it, you're welcome.

<!--- Please provide a general summary of your changes in the title above -->

## Description
Jamie used the wrong thing and now I have fixed it, you're welcome.

## Related Issue
When you delete something from a collection, it incorrectly stored the wrong deletedData in the history, this meant that using the undo() function failed.

## Context
This makes the delete function store the correct data that has been deleted in history.

## How Has This Been Tested?
I tested this by deleting something, and then undoing the action and finding it worked. 