### PR TITLE
Docs: add alias for pulsejs.org

### DIFF
--- a/now.json
+++ b/now.json
@@ -2,6 +2,7 @@
     "version": 2,
     "name": "pulsejs-docs",
     "public": true,
+    "alias": "pulsejs.org",
     "regions": ["sfo1", "lhr1"],
     "builds": [
         {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Description
<!--- Please describe all your changes in detail -->
This will automatically alias pulsejs.org to the current deployment on now.sh.
## Related Issue
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please provide a link to the issue here: -->

## Context
<!--- Why is this change required/wanted? What problem does it solve? -->
<!--- If this fixes an open issue, please provide a link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include information about your testing environment, and the tests you ran to -->
<!--- see how your change might have affects other areas of the code, etc. -->
